### PR TITLE
test: assert that PLogMetadata is NotNil in partial test

### DIFF
--- a/logger/common_test.go
+++ b/logger/common_test.go
@@ -99,6 +99,8 @@ func checkLogFile(t *testing.T, fileName string, expectedNumLines int,
 		require.NoError(t, err)
 		if len(expectedPartialOrdinalSequence) > 0 && lines < len(expectedPartialOrdinalSequence) {
 			// check partial fields
+			// if the message is partial it will have a PLogMetaData
+			require.NotNil(t, msg.PLogMetaData)
 			require.Equal(t, expectedPartialOrdinalSequence[lines], msg.PLogMetaData.Ordinal)
 			if msg.PLogMetaData.Ordinal < lastPartialOrdinal {
 				// new split message so new partial ID


### PR DESCRIPTION
Signed-off-by: Wesley Pettit <wppttt@amazon.com>

This just ensures that if we ever break the partial metadata feature, the test will fail with a nice error on this new line, instead of failing with a null pointer exception. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
