### PR TITLE
ci: simplify go linter and rename it to differentiate with other linters

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,25 +8,23 @@ on:
       - main
 
 jobs:
-  lint:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ 'ubuntu-22.04' ]
-
-    name: ${{ matrix.os }} / Lint
-    runs-on: ${{ matrix.os }}
+  # It's recommended to run golangci-lint in a job separate from other jobs (go test, etc) because different jobs run in parallel.
+  go-linter:
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
           go-version: '1.20'
-          cache: false
+          cache: true
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3.3.0
+        uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.52.2
-      
+          # Pin the version in case all the builds start to fail at the same time.
+          # There may not be an automatic way (e.g., dependabot) to update a specific parameter of a GitHub Action,
+          # so we will just update it manually whenever it makes sense (e.g., a feature that we want is added).
+          version: v1.53.3
+          args: --fix=false --timeout=5m
   build:
     strategy:
       fail-fast: false


### PR DESCRIPTION
1. Remame to "go-linter" to prevent conflict with other linters. (Will add mdlint, pr title lint later)
2. Lock compute to ubuntu-latest to simplify
3. Update versions.
4. Add comments.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
