### PR TITLE
chore: add Go 1.21 support to CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,13 +24,13 @@ jobs:
           # Pin the version in case all the builds start to fail at the same time.
           # There may not be an automatic way (e.g., dependabot) to update a specific parameter of a GitHub Action,
           # so we will just update it manually whenever it makes sense (e.g., a feature that we want is added).
-          version: v1.53.3
+          version: v1.54.0
           args: --fix=false --timeout=5m
   build:
     strategy:
       fail-fast: false
       matrix:
-        go: [ '1.17', '1.18', '1.19', '1.20' ]
+        go: [ '1.17', '1.18', '1.19', '1.20', '1.21' ]
         os: [ 'ubuntu-22.04', 'windows-2022' ]
 
     name: ${{ matrix.os }} / Go ${{ matrix.go }}

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ mdlint-ctr:
 .get-deps-stamp:
 	GO111MODULE=off GOBIN=$(DEPSPATH) go get golang.org/x/tools/cmd/goimports
 	GOBIN=$(DEPSPATH) go get github.com/golang/mock/mockgen@v1.4.1
-	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(DEPSPATH) v1.53.3
+	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(DEPSPATH) v1.54.0
 	$(DEPSPATH)/golangci-lint --version
 	touch .get-deps-stamp
 


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Go 1.21 is released. This PR adds support to the CI pipeline.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
