### PR TITLE
ci: change cloudwatch test infra from real AWS to local stack

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,11 +62,17 @@ jobs:
         with:
           go-version: ${{ matrix.go }}
           cache: false
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.ROLE }}
-          aws-region: ${{ secrets.REGION }}
+      - name: Start LocalStack # Copy from https://docs.localstack.cloud/user-guide/ci/github-actions/
+        run: |
+          pip install localstack awscli-local[ver1] # install LocalStack cli and awslocal
+          docker pull localstack/localstack         # Make sure to pull the latest version of the image
+          localstack start -d                       # Start LocalStack in the background
+          
+          echo "Waiting for LocalStack startup..."  # Wait 30 seconds for the LocalStack container
+          localstack wait -t 30                     # to become ready before timing out 
+          echo "Startup complete"
+          
+          awslocal logs create-log-group --log-group-name test-shim-logger
       - name: install and start containerd
         shell: bash
         run: sudo scripts/install-containerd

--- a/scripts/start-ecs-local-endpoint
+++ b/scripts/start-ecs-local-endpoint
@@ -1,10 +1,9 @@
 #!/bin/bash
 # ecs local endpoint can only use credentials in aws credential file instead of env vars
 
-aws configure set aws_access_key_id $AWS_ACCESS_KEY_ID --profile default
-aws configure set aws_secret_access_key $AWS_SECRET_ACCESS_KEY --profile default
-aws configure set aws_session_token $AWS_SESSION_TOKEN --profile default
+aws configure set aws_access_key_id dummy-aws-access-key-id --profile default
+aws configure set aws_secret_access_key dummy-aws-secret-access-key --profile default
 docker run -d --name ecs-local-endpoint -p 51679:51679 \
--v $HOME/.aws/:/home/.aws/ -e AWS_REGION=us-west-2 \
+-v $HOME/.aws/:/home/.aws/ -e AWS_REGION=us-east-1 \
 -e HOME="/home" -e AWS_PROFILE=default -e ECS_LOCAL_METADATA_PORT=51679 \
 amazon/amazon-ecs-local-container-endpoints


### PR DESCRIPTION
*Description of changes:*

Real AWS credentials are not available in the PR workflow from forked repo. (Previous workflow failure: https://github.com/aws/shim-loggers-for-containerd/actions/runs/6204238070/job/16846048871) So switching to local stack to remove the usage of real credentials.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
