### PR TITLE
ci: pin the previous local stack version to fix the failure

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,8 +64,9 @@ jobs:
           cache: false
       - name: Start LocalStack # Copy from https://docs.localstack.cloud/user-guide/ci/github-actions/
         run: |
-          pip install localstack awscli-local[ver1] # install LocalStack cli and awslocal
-          docker pull localstack/localstack         # Make sure to pull the latest version of the image
+          LOCALSTACK_VERSION=2.2.0
+          pip install localstack==${LOCALSTACK_VERSION} awscli-local[ver1] # install LocalStack cli and awslocal
+          docker pull localstack/localstack:${LOCALSTACK_VERSION}         # Make sure to pull the latest version of the image
           localstack start -d                       # Start LocalStack in the background
           
           echo "Waiting for LocalStack startup..."  # Wait 30 seconds for the LocalStack container


### PR DESCRIPTION
*Description of changes:*

Suppress the failure caused by https://github.com/localstack/localstack/issues/9253


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
