### PR TITLE
ci: reenable wastedassign linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -50,8 +50,7 @@ linters:
     - unconvert
     - unparam
     - usestdlibvars
-    # TODO: Enable wastedassign after https://github.com/sanposhiho/wastedassign/issues/41 is fixed.
-    # - wastedassign
+    - wastedassign
     - whitespace
     - stylecheck
 issues:


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
This change reenables wastedassign for golangci-lint in CI.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
