### PR TITLE
ci: fix local prefix for goimports

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -5,7 +5,7 @@ linters-settings:
   goheader:
     template-path: copyright_header
   goimports:
-    local-prefixes: github.com/runfinch/finch
+    local-prefixes: github.com/aws/shim-loggers-for-containerd
   gosec:
     config:
       G306: "0o644"


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
This change fixes the local import check for golangci-lint goimports in CI.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
