### PR TITLE
chore: add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Global (repository-wide) owners:
+*    @aws/shim-loggers-for-containerd


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
This change adds codeowners for global shim-loggers-for-containerd repository.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
