### PR TITLE
fix: benchmarks GitHub website page title

### DIFF
--- a/dev/bench/index.html
+++ b/dev/bench/index.html
@@ -36,7 +36,7 @@
     </style>
 </head>
 <body>
-<h1>Finch Benchmark</h1>
+<h1>Shim Loggers Benchmarks</h1>
 <a href="./awslogs/ubuntu/index.html">awslogs ubuntu</a>
 <a href="./fluentd/ubuntu/index.html">fluentd ubuntu</a>
 <a href="./splunk/ubuntu/index.html">splunk ubuntu</a>


### PR DESCRIPTION
*Issue #, if available:*
Copy and paste error from initial setup of the benchmark website from Finch

*Description of changes:*
This change fixes the title on the benchmark website. i.e. https://aws.github.io/shim-loggers-for-containerd/dev/bench/

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
