### PR TITLE
ci: add git secrets scanning

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,6 +8,25 @@ on:
       - main
 
 jobs:
+  git-secrets:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Pull latest awslabs/git-secrets repo
+        uses: actions/checkout@v4
+        with:
+           repository: awslabs/git-secrets
+           ref: 1.3.0
+           fetch-tags: true
+           path: git-secrets
+      - name: Install git secrets from source
+        run: sudo make install
+        working-directory: git-secrets
+      - uses: actions/checkout@v4
+      - name: Scan repository for git secrets
+        run: |
+          git secrets --register-aws
+          git secrets --scan-history
+
   # It's recommended to run golangci-lint in a job separate from other jobs (go test, etc) because different jobs run in parallel.
   go-linter:
     strategy:


### PR DESCRIPTION
*Issue #, if available:*
Contributors can accidentally submit git secrets to version control.

*Description of changes:*
This change adds a GitHub Actions job to validate git secrets are not submitted to version control.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
