### PR TITLE
refactor: [WIP] Add instrumentations when routing logs to the log driver

### DIFF
--- a/logger/buffered_logger.go
+++ b/logger/buffered_logger.go
@@ -125,6 +125,7 @@ func (bl *bufferedLogger) Start(
 		pipe := p
 
 		errGroup.Go(func() error {
+			debug.SendEventsToLog(DaemonName, fmt.Sprintf("Reading logs from pipe %s", source), debug.DEBUG, 0)
 			logErr := bl.saveLogMessagesToRingBuffer(ctx, pipe, source)
 			if logErr != nil {
 				err := fmt.Errorf("failed to send logs from pipe %s: %w", source, logErr)

--- a/logger/common_test.go
+++ b/logger/common_test.go
@@ -212,7 +212,6 @@ func TestNewInfo(t *testing.T) {
 // TestTracingLogRouting verifies the expected number of bytes are read from the source/containers' pipe files and the
 // expected number of bytes are sent to the destination/the log driver.
 func TestTracingLogRouting(t *testing.T) {
-
 	// Create a tmp file that used to mock the io pipe where the logger reads log
 	// messages from.
 	tmpIOSource, err := os.CreateTemp("", "")

--- a/logger/common_test.go
+++ b/logger/common_test.go
@@ -13,6 +13,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -206,4 +207,55 @@ func TestNewInfo(t *testing.T) {
 	}
 	info := NewInfo(testContainerID, testContainerName, WithConfig(config))
 	require.Equal(t, config, info.Config)
+}
+
+// TestTracingLogRouting verifies the expected number of bytes are read from the source/containers' pipe files and the
+// expected number of bytes are sent to the destination/the log driver.
+func TestTracingLogRouting(t *testing.T) {
+
+	// Create a tmp file that used to mock the io pipe where the logger reads log
+	// messages from.
+	tmpIOSource, err := os.CreateTemp("", "")
+	require.NoError(t, err)
+	defer os.Remove(tmpIOSource.Name()) //nolint:errcheck // testing only
+	var (
+		testStdout bytes.Buffer
+		testStderr bytes.Buffer
+	)
+	// Create two pipes for stdout and stderr.
+	inputForStdout := "1234567890\n"
+	countOfNewLinesForStdout := 1
+	_, err = testStdout.WriteString(inputForStdout)
+	require.NoError(t, err)
+	inputForStderr := "123 456 789 0\n123 456 789 0\n123 456 789 0\n"
+	countOfNewLinesForStderr := 3
+	_, err = testStderr.WriteString(inputForStderr)
+	require.NoError(t, err)
+	// Create a tmp file that used to inside customized dummy Log function where the
+	// logger sends log messages to.
+	tmpDest, err := os.CreateTemp("", "")
+	require.NoError(t, err)
+	defer os.Remove(tmpDest.Name()) //nolint:errcheck // testing only
+	logDestinationFileName = tmpDest.Name()
+
+	l := &Logger{
+		Info:              &dockerlogger.Info{},
+		Stream:            &dummyClient{t},
+		bufferSizeInBytes: DefaultBufSizeInBytes,
+		maxReadBytes:      defaultMaxReadBytes,
+		Stdout:            &testStdout,
+		Stderr:            &testStderr,
+	}
+	err = l.Start(
+		context.TODO(),
+		&dummyCleanupTime,
+		func() error { return nil },
+	)
+	require.NoError(t, err)
+
+	require.Equal(t, uint64(len(inputForStdout)+len(inputForStderr)), atomic.LoadUint64(&bytesReadFromSrc))
+	// Exclude the new line characters because they will be removed when sending logs to the log driver.
+	require.Equal(t,
+		uint64(len(inputForStdout)+len(inputForStderr)-countOfNewLinesForStdout-countOfNewLinesForStderr),
+		atomic.LoadUint64(&bytesSentToDst))
 }


### PR DESCRIPTION
*Issue #, if available:* NA

*Description of changes:* this PR is to add instrumentations when the shim logger are consuming data from the source / container pipes and sending data to the destination / the configured log drivers. Specifically we will print out the number of bytes we read from the source and the number of bytes we send to the destination every 1 minutes. This can help us monitor the data workflow and check if any potential issues when routing logs.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
