### PR TITLE
refactor: Add instrumentations when routing logs to the log driver

### DIFF
--- a/logger/buffered_logger.go
+++ b/logger/buffered_logger.go
@@ -15,7 +15,6 @@ import (
 
 	types "github.com/docker/docker/api/types/backend"
 	dockerlogger "github.com/docker/docker/daemon/logger"
-
 	"golang.org/x/sync/errgroup"
 )
 
@@ -102,7 +101,7 @@ func (bl *bufferedLogger) Start(
 	atomic.StoreUint64(&bytesReadFromSrc, 0)
 	atomic.StoreUint64(&bytesSentToDst, 0)
 	atomic.StoreUint64(&numberOfNewLineChars, 0)
-	go func(){
+	go func() {
 		startTracingLogRouting(bl.containerID, stopTracingLogRoutingChan)
 		logWG.Done()
 	}()

--- a/logger/buffered_logger.go
+++ b/logger/buffered_logger.go
@@ -101,6 +101,7 @@ func (bl *bufferedLogger) Start(
 	stopTracingLogRoutingChan := make(chan bool, 1)
 	atomic.StoreUint64(&bytesReadFromSrc, 0)
 	atomic.StoreUint64(&bytesSentToDst, 0)
+	atomic.StoreUint64(&numberOfNewLineChars, 0)
 	go func(){
 		startTracingLogRouting(bl.containerID, stopTracingLogRoutingChan)
 		logWG.Done()

--- a/logger/common.go
+++ b/logger/common.go
@@ -50,7 +50,7 @@ const (
 	traceLogRoutingInterval = 1 * time.Minute
 )
 
-var(
+var (
 	// bytesReadFromSrc defines the number of bytes we read from the source(all pipes) within given time interval.
 	bytesReadFromSrc uint64
 	// bytesSentToDst defines the number of bytes we send to the destination(the corresponding log driver) within given
@@ -189,7 +189,7 @@ func (l *Logger) Start(
 	atomic.StoreUint64(&bytesReadFromSrc, 0)
 	atomic.StoreUint64(&bytesSentToDst, 0)
 	atomic.StoreUint64(&numberOfNewLineChars, 0)
-	go func(){
+	go func() {
 		startTracingLogRouting(l.Info.ContainerID, stopTracingLogRoutingChan)
 		logWG.Done()
 	}()
@@ -411,7 +411,6 @@ func (l *Logger) Read(
 	}
 }
 
-
 // startTracingLogRouting will emit logs every 1 minute where it counts how many bytes are read from the source
 // (container pipes) within given interval and how many bytes are sent to the destination (the log driver).
 func startTracingLogRouting(containerID string, stop chan bool) {
@@ -425,12 +424,12 @@ func startTracingLogRouting(containerID string, stop chan bool) {
 			// var. To avoid race conditions between these two, we should use atomic variables.
 			previousBytesReadFromSrc := atomic.SwapUint64(&bytesReadFromSrc, 0)
 			previousBytesSentToDst := atomic.SwapUint64(&bytesSentToDst, 0)
-			previousNumberOfLogLines := atomic.SwapUint64(&numberOfNewLineChars, 0)
+			previousNumberOfNewLineChars := atomic.SwapUint64(&numberOfNewLineChars, 0)
 			debug.SendEventsToLog(
 				containerID,
-				fmt.Sprintf("Within last minute, reading %d bytes from the source " +
-					"and %d bytes are sent to the destination and %d new line characters are ignored.",
-					previousBytesReadFromSrc, previousBytesSentToDst, previousNumberOfLogLines),
+				fmt.Sprintf("Within last minute, reading %d bytes from the source. "+
+					"And %d bytes are sent to the destination and %d new line characters are ignored.",
+					previousBytesReadFromSrc, previousBytesSentToDst, previousNumberOfNewLineChars),
 				debug.DEBUG,
 				0)
 		case <-stop:

--- a/logger/common.go
+++ b/logger/common.go
@@ -434,8 +434,12 @@ func startTracingLogRouting(containerID string, stop chan bool) {
 				0)
 		case <-stop:
 			debug.SendEventsToLog(containerID,
-				fmt.Sprintf("Reading %d bytes from the source and sending %d bytes to the destination",
-					atomic.LoadUint64(&bytesReadFromSrc), atomic.LoadUint64(&bytesSentToDst)),
+				fmt.Sprintf("Reading %d bytes from the source. "+
+					"And %d bytes are sent to the destination and %d new line characters are ignored.",
+					atomic.LoadUint64(&bytesReadFromSrc),
+					atomic.LoadUint64(&bytesSentToDst),
+					atomic.LoadUint64(&numberOfNewLineChars),
+				),
 				debug.DEBUG, 0)
 			ticker.Stop()
 			debug.SendEventsToLog(containerID, "Stopped the ticker...", debug.DEBUG, 0)

--- a/logger/common_linux_test.go
+++ b/logger/common_linux_test.go
@@ -38,7 +38,7 @@ func TestTracingLogRouting(t *testing.T) {
 	countOfNewLinesForStderr := 3
 	_, err = testStderr.WriteString(inputForStderr)
 	require.NoError(t, err)
-	// Create a tmp file that used to inside customized dummy Log function where the
+	// Create a tmp file that used in customized dummy log function where the
 	// logger sends log messages to.
 	tmpDest, err := os.CreateTemp("", "")
 	require.NoError(t, err)

--- a/logger/common_linux_test.go
+++ b/logger/common_linux_test.go
@@ -65,4 +65,6 @@ func TestTracingLogRouting(t *testing.T) {
 	require.Equal(t,
 		uint64(len(inputForStdout)+len(inputForStderr)-countOfNewLinesForStdout-countOfNewLinesForStderr),
 		atomic.LoadUint64(&bytesSentToDst))
+	require.Equal(t,
+		uint64(countOfNewLinesForStdout+countOfNewLinesForStderr), atomic.LoadUint64(&numberOfNewLineChars))
 }

--- a/logger/common_linux_test.go
+++ b/logger/common_linux_test.go
@@ -1,0 +1,68 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build unit
+// +build unit
+
+package logger
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"sync/atomic"
+	"testing"
+
+	dockerlogger "github.com/docker/docker/daemon/logger"
+	"github.com/stretchr/testify/require"
+)
+
+// TestTracingLogRouting verifies the expected number of bytes are read from the source/containers' pipe files and the
+// expected number of bytes are sent to the destination/the log driver.
+func TestTracingLogRouting(t *testing.T) {
+	// Create a tmp file that used to mock the io pipe where the logger reads log
+	// messages from.
+	tmpIOSource, err := os.CreateTemp("", "")
+	require.NoError(t, err)
+	defer os.Remove(tmpIOSource.Name()) //nolint:errcheck // testing only
+	var (
+		testStdout bytes.Buffer
+		testStderr bytes.Buffer
+	)
+	// Create two pipes for stdout and stderr.
+	inputForStdout := "1234567890\n"
+	countOfNewLinesForStdout := 1
+	_, err = testStdout.WriteString(inputForStdout)
+	require.NoError(t, err)
+	inputForStderr := "123 456 789 0\n123 456 789 0\n123 456 789 0\n"
+	countOfNewLinesForStderr := 3
+	_, err = testStderr.WriteString(inputForStderr)
+	require.NoError(t, err)
+	// Create a tmp file that used to inside customized dummy Log function where the
+	// logger sends log messages to.
+	tmpDest, err := os.CreateTemp("", "")
+	require.NoError(t, err)
+	defer os.Remove(tmpDest.Name()) //nolint:errcheck // testing only
+	logDestinationFileName = tmpDest.Name()
+
+	l := &Logger{
+		Info:              &dockerlogger.Info{},
+		Stream:            &dummyClient{t},
+		bufferSizeInBytes: DefaultBufSizeInBytes,
+		maxReadBytes:      defaultMaxReadBytes,
+		Stdout:            &testStdout,
+		Stderr:            &testStderr,
+	}
+	err = l.Start(
+		context.TODO(),
+		&dummyCleanupTime,
+		func() error { return nil },
+	)
+	require.NoError(t, err)
+
+	require.Equal(t, uint64(len(inputForStdout)+len(inputForStderr)), atomic.LoadUint64(&bytesReadFromSrc))
+	// Exclude the new line characters because they will be removed when sending logs to the log driver.
+	require.Equal(t,
+		uint64(len(inputForStdout)+len(inputForStderr)-countOfNewLinesForStdout-countOfNewLinesForStderr),
+		atomic.LoadUint64(&bytesSentToDst))
+}

--- a/logger/common_test.go
+++ b/logger/common_test.go
@@ -13,7 +13,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -207,55 +206,4 @@ func TestNewInfo(t *testing.T) {
 	}
 	info := NewInfo(testContainerID, testContainerName, WithConfig(config))
 	require.Equal(t, config, info.Config)
-}
-
-// TestTracingLogRouting verifies the expected number of bytes are read from the source/containers' pipe files and the
-// expected number of bytes are sent to the destination/the log driver.
-func TestTracingLogRouting(t *testing.T) {
-
-	// Create a tmp file that used to mock the io pipe where the logger reads log
-	// messages from.
-	tmpIOSource, err := os.CreateTemp("", "")
-	require.NoError(t, err)
-	defer os.Remove(tmpIOSource.Name()) //nolint:errcheck // testing only
-	var (
-		testStdout bytes.Buffer
-		testStderr bytes.Buffer
-	)
-	// Create two pipes for stdout and stderr.
-	inputForStdout := "1234567890\n"
-	countOfNewLinesForStdout := 1
-	_, err = testStdout.WriteString(inputForStdout)
-	require.NoError(t, err)
-	inputForStderr := "123 456 789 0\n123 456 789 0\n123 456 789 0\n"
-	countOfNewLinesForStderr := 3
-	_, err = testStderr.WriteString(inputForStderr)
-	require.NoError(t, err)
-	// Create a tmp file that used to inside customized dummy Log function where the
-	// logger sends log messages to.
-	tmpDest, err := os.CreateTemp("", "")
-	require.NoError(t, err)
-	defer os.Remove(tmpDest.Name()) //nolint:errcheck // testing only
-	logDestinationFileName = tmpDest.Name()
-
-	l := &Logger{
-		Info:              &dockerlogger.Info{},
-		Stream:            &dummyClient{t},
-		bufferSizeInBytes: DefaultBufSizeInBytes,
-		maxReadBytes:      defaultMaxReadBytes,
-		Stdout:            &testStdout,
-		Stderr:            &testStderr,
-	}
-	err = l.Start(
-		context.TODO(),
-		&dummyCleanupTime,
-		func() error { return nil },
-	)
-	require.NoError(t, err)
-
-	require.Equal(t, uint64(len(inputForStdout)+len(inputForStderr)), atomic.LoadUint64(&bytesReadFromSrc))
-	// Exclude the new line characters because they will be removed when sending logs to the log driver.
-	require.Equal(t,
-		uint64(len(inputForStdout)+len(inputForStderr)-countOfNewLinesForStdout-countOfNewLinesForStderr),
-		atomic.LoadUint64(&bytesSentToDst))
 }

--- a/logger/common_test.go
+++ b/logger/common_test.go
@@ -13,6 +13,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -206,4 +207,55 @@ func TestNewInfo(t *testing.T) {
 	}
 	info := NewInfo(testContainerID, testContainerName, WithConfig(config))
 	require.Equal(t, config, info.Config)
+}
+
+// TestTracingLogRouting verifies the expected number of bytes are read from the source/containers' pipe files and the
+// expected number of bytes are sent to the destination/the log driver.
+func TestTracingLogRouting(t *testing.T) {
+
+	// Create a tmp file that used to mock the io pipe where the logger reads log
+	// messages from.
+	tmpIOSource, err := os.CreateTemp("", "")
+	require.NoError(t, err)
+	defer os.Remove(tmpIOSource.Name()) //nolint:errcheck // testing only
+	var (
+		testStdout bytes.Buffer
+		testStderr bytes.Buffer
+	)
+	// Create two pipes for stdout and stderr.
+	inputForStdout := "1234567890\n"
+	countOfNewLinesForStdout := 1
+	_, err = testStdout.WriteString(inputForStdout)
+	require.NoError(t, err)
+	inputForStderr := "123 456 789 0\n123 456 789 0\n123 456 789 0\n"
+	countOfNewLinesForStderr := 3
+	_, err = testStderr.WriteString(inputForStderr)
+	require.NoError(t, err)
+	// Create a tmp file that used to inside customized dummy Log function where the
+	// logger sends log messages to.
+	tmpDest, err := os.CreateTemp("", "")
+	require.NoError(t, err)
+	defer os.Remove(tmpDest.Name()) //nolint:errcheck // testing only
+	logDestinationFileName = tmpDest.Name()
+
+	l := &Logger{
+		Info:              &dockerlogger.Info{},
+		Stream:            &dummyClient{t},
+		bufferSizeInBytes: DefaultBufSizeInBytes,
+		maxReadBytes:      defaultMaxReadBytes,
+		Stdout:            &testStdout,
+		Stderr:            &testStderr,
+	}
+	err = l.Start(
+		context.TODO(),
+		&dummyCleanupTime,
+		func() error { return nil },
+	)
+	require.NoError(t, err)
+
+	require.Equal(t, uint64(len(inputForStdout)+len(inputForStderr)), atomic.LoadUint64(&bytesReadFromSrc))
+	// Exclude the new line characters because they will be removed when sending logs to the log driver.
+	require.Equal(t,
+		uint64(len(inputForStdout)+len(inputForStderr)-countOfNewLinesForStdout-countOfNewLinesForStderr),
+		atomic.LoadUint64(&bytesSentToDst))
 }


### PR DESCRIPTION
*Issue #, if available:* NA

*Description of changes:* this PR is to add instrumentations when the shim logger are consuming data from the source / container pipes and sending data to the destination / the configured log drivers. Specifically we will print out the number of bytes we read from the source and the number of bytes we send to the destination every 1 minute. This can help us monitor the data workflow and check if any potential issues when routing logs.

One example about what the logs look like
```
---
| @timestamp | cmdName | message |
| --- | --- | --- |
| 2024-04-03 23:34:57.000 | shim-loggers-fo | Driver: awslogs |
| 2024-04-03 23:34:57.000 | shim-loggers-fo | Starting log streaming for non-blocking mode awslogs driver |
| 2024-04-03 23:34:57.000 | shim-loggers-fo | Starting log streaming for awslogs driver |
| 2024-04-03 23:34:57.000 | shim-loggers-fo | Reading logs from pipe stderr |
| 2024-04-03 23:34:57.000 | shim-loggers-fo | Starting the ticker... |
| 2024-04-03 23:34:57.000 | shim-loggers-fo | Reading logs from pipe stdout |
| 2024-04-03 23:34:57.000 | shim-loggers-fo | Starting consuming logs from ring buffer |
| 2024-04-03 23:35:57.000 | shim-loggers-fo | Within last minute, reading 55 bytes from the source. And 50 bytes are sent to the destination and 5 new line characters are ignored. |
| 2024-04-03 23:36:57.000 | shim-loggers-fo | Within last minute, reading 55 bytes from the source. And 50 bytes are sent to the destination and 5 new line characters are ignored. |
| 2024-04-03 23:37:57.000 | shim-loggers-fo | Within last minute, reading 55 bytes from the source. And 50 bytes are sent to the destination and 5 new line characters are ignored. |
| 2024-04-03 23:38:57.000 | shim-loggers-fo | Within last minute, reading 55 bytes from the source. And 50 bytes are sent to the destination and 5 new line characters are ignored. |
| 2024-04-03 23:39:57.000 | shim-loggers-fo | Within last minute, reading 55 bytes from the source. And 50 bytes are sent to the destination and 5 new line characters are ignored. |
| 2024-04-03 23:40:57.000 | shim-loggers-fo | Within last minute, reading 55 bytes from the source. And 50 bytes are sent to the destination and 5 new line characters are ignored. |
| 2024-04-03 23:41:57.000 | shim-loggers-fo | Within last minute, reading 55 bytes from the source. And 50 bytes are sent to the destination and 5 new line characters are ignored. |
| 2024-04-03 23:42:57.000 | shim-loggers-fo | Within last minute, reading 55 bytes from the source. And 50 bytes are sent to the destination and 5 new line characters are ignored. |
| 2024-04-03 23:43:11.000 | shim-loggers-fo | Pipe stdout is closed |
| 2024-04-03 23:43:11.000 | shim-loggers-fo | Pipe stderr is closed |
| 2024-04-03 23:43:12.000 | shim-loggers-fo | All pipes are closed, flushing buffer. |
| 2024-04-03 23:43:12.000 | shim-loggers-fo | Sleeping 10s for cleanning up. |
| 2024-04-03 23:43:22.000 | shim-loggers-fo | Sending signal to stop the ticker. |
| 2024-04-03 23:43:22.000 | shim-loggers-fo | Reading 22 bytes from the source. And 20 bytes are sent to the destination and 2 new line characters are ignored. |
| 2024-04-03 23:43:22.000 | shim-loggers-fo | Stopped the ticker... |
| 2024-04-03 23:43:22.000 | shim-loggers-fo | Logging finished |
---
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
