### PR TITLE
fix: log errors from sendLogs with correct variable in common#Start()

### DIFF
--- a/logger/common.go
+++ b/logger/common.go
@@ -208,7 +208,7 @@ func (l *Logger) Start(
 		errGroup.Go(func() error {
 			logErr := l.sendLogs(ctx, pipe, source, cleanupTime)
 			if logErr != nil {
-				err := fmt.Errorf("failed to send logs from pipe %s: %w", source, err)
+				err := fmt.Errorf("failed to send logs from pipe %s: %w", source, logErr)
 				debug.SendEventsToLog(DaemonName, err.Error(), debug.ERROR, 1)
 				return err
 			}


### PR DESCRIPTION
*Issue #, if available:* n/a

fixing nil error log

`    "message": "failed to send logs from pipe stdout: %!w(<nil>)",`

*Description of changes:*

log the correct error variable

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
