### PR TITLE
ci: bump e2e test go version and linter version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
           # Pin the version in case all the builds start to fail at the same time.
           # There may not be an automatic way (e.g., dependabot) to update a specific parameter of a GitHub Action,
           # so we will just update it manually whenever it makes sense (e.g., a feature that we want is added).
-          version: v1.54.0
+          version: v1.60.3
           args: --build-tags e2e,unit --fix=false --timeout=5m --out-format=colored-line-number
   unit-tests:
     strategy:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: [ '1.20', '1.21' ]
+        go: [ '1.21', '1.22' ]
         os: [ ubuntu-latest, windows-latest ]
 
     name: Unit Tests / ${{ matrix.os }} / Go ${{ matrix.go }}
@@ -49,7 +49,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: [ '1.20', '1.21' ]
+        go: [ '1.21', '1.22' ]
         os: [ ubuntu-latest ] # TODO: Add Windows e2e tests: https://github.com/aws/shim-loggers-for-containerd/issues/68
     name: E2E tests / awslogs / ${{ matrix.os }} / Go ${{ matrix.go }}
     runs-on: ${{ matrix.os }}
@@ -82,7 +82,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: [ '1.20', '1.21' ]
+        go: [ '1.21', '1.22' ]
         os: [ ubuntu-latest ] # TODO: Add Windows e2e tests: https://github.com/aws/shim-loggers-for-containerd/issues/68
     name: E2E tests / fluentd / ${{ matrix.os }} / Go ${{ matrix.go }}
     runs-on: ${{ matrix.os }}
@@ -109,7 +109,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: [ '1.20', '1.21' ]
+        go: [ '1.21', '1.22' ]
         os: [ ubuntu-latest ] # TODO: Add Windows e2e tests: https://github.com/aws/shim-loggers-for-containerd/issues/68
     name: E2E tests / splunk / ${{ matrix.os }} / Go ${{ matrix.go }}
     runs-on: ${{ matrix.os }}

--- a/e2e/awslogs_test.go
+++ b/e2e/awslogs_test.go
@@ -50,7 +50,7 @@ var testAwslogs = func() {
 		var cwClient *cloudwatchlogs.Client
 		ginkgo.BeforeEach(func() {
 			// Reference to set up Go client for aws local stack: https://docs.localstack.cloud/user-guide/integrations/sdks/go/.
-			customResolver := aws.EndpointResolverWithOptionsFunc(func(service, region string, options ...interface{}) (aws.Endpoint, error) {
+			customResolver := aws.EndpointResolverWithOptionsFunc(func(_, _ string, _ ...interface{}) (aws.Endpoint, error) {
 				return aws.Endpoint{
 					PartitionID:   "aws",
 					URL:           testAwslogsEndpoint,


### PR DESCRIPTION
*Issue #, if available:* Build failures when merging https://github.com/aws/shim-loggers-for-containerd/pull/185

*Description of changes:*
A new version of the `github.com/docker/docker` package requires the `github.com/moby/sys/blob/main/userns` package, which [uses `sync.OnceValue`](https://github.com/moby/sys/blob/main/userns/userns_linux.go). Since `sync.OnceValue` was added in go 1.21.0 ([doc link](https://pkg.go.dev/sync#OnceValue)), the tests which run on go 1.20.x are failing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
