### PR TITLE
feat: add support for awslogs-format

### DIFF
--- a/args.go
+++ b/args.go
@@ -150,6 +150,7 @@ func getAWSLogsArgs() (*awslogs.Args, error) {
 		MultilinePattern:    viper.GetString(awslogs.MultilinePatternKey),
 		DatetimeFormat:      viper.GetString(awslogs.DatetimeFormatKey),
 		Endpoint:            viper.GetString(awslogs.EndpointKey),
+		LogsFormatHeader:    viper.GetString(awslogs.LogFormatKey),
 	}, nil
 }
 

--- a/init.go
+++ b/init.go
@@ -106,6 +106,7 @@ func initAWSLogsOpts() {
 	pflag.String(awslogs.MultilinePatternKey, "", "Support multiline pattern for debug")
 	pflag.String(awslogs.DatetimeFormatKey, "", "Multiline pattern in strftime format")
 	pflag.String(awslogs.EndpointKey, "", "The CloudWatch endpoint to use")
+	pflag.String(awslogs.LogFormatKey, "", "Explicitly set the json/emf header for PutLogEvents")
 }
 
 // initFluentdOpts initialize fluentd driver specified options.

--- a/logger/awslogs/logger_test.go
+++ b/logger/awslogs/logger_test.go
@@ -22,6 +22,7 @@ const (
 	testMultilinePattern    = "test-multiline-pattern"
 	testDatetimeFormat      = "test-datetime-format"
 	testEndpoint            = "test-endpoint"
+	testJSONEmfLogformat    = "json/emf"
 )
 
 var (
@@ -34,6 +35,48 @@ var (
 		CreateStream:        testCreateStream,
 		MultilinePattern:    testMultilinePattern,
 		DatetimeFormat:      testDatetimeFormat,
+		Endpoint:            testEndpoint,
+		LogsFormatHeader:    testJSONEmfLogformat,
+	}
+)
+
+var (
+	argsWithoutHeader = &Args{
+		Group:               testGroup,
+		Region:              testRegion,
+		Stream:              testStream,
+		CredentialsEndpoint: testCredentialsEndpoint,
+		CreateGroup:         testCreateGroup,
+		CreateStream:        testCreateStream,
+		MultilinePattern:    testMultilinePattern,
+		DatetimeFormat:      testDatetimeFormat,
+		Endpoint:            testEndpoint,
+	}
+)
+
+var (
+	argsWithoutMultiline = &Args{
+		Group:               testGroup,
+		Region:              testRegion,
+		Stream:              testStream,
+		CredentialsEndpoint: testCredentialsEndpoint,
+		CreateGroup:         testCreateGroup,
+		CreateStream:        testCreateStream,
+		DatetimeFormat:      testDatetimeFormat,
+		Endpoint:            testEndpoint,
+		LogsFormatHeader:    testJSONEmfLogformat,
+	}
+)
+
+var (
+	argsValid = &Args{
+		Group:               testGroup,
+		Region:              testRegion,
+		Stream:              testStream,
+		CredentialsEndpoint: testCredentialsEndpoint,
+		CreateGroup:         testCreateGroup,
+		CreateStream:        testCreateStream,
+		MultilinePattern:    testMultilinePattern,
 		Endpoint:            testEndpoint,
 	}
 )
@@ -51,8 +94,71 @@ func TestGetAWSLogsConfig(t *testing.T) {
 		MultilinePatternKey:    testMultilinePattern,
 		DatetimeFormatKey:      testDatetimeFormat,
 		EndpointKey:            testEndpoint,
+		LogFormatKey:           testJSONEmfLogformat,
 	}
 
 	config := getAWSLogsConfig(args)
 	require.Equal(t, expectedConfig, config)
+}
+
+// TestGetAWSLogsConfigWithoutFormatHeader tests if getAWSLogsConfig function converts log config
+// maps correctly if LogsFormatHeader is omitted.
+func TestGetAWSLogsConfigWithoutFormatHeader(t *testing.T) {
+	expectedConfig := map[string]string{
+		GroupKey:               testGroup,
+		RegionKey:              testRegion,
+		StreamKey:              testStream,
+		CredentialsEndpointKey: testCredentialsEndpoint,
+		CreateGroupKey:         testCreateGroup,
+		CreateStreamKey:        testCreateStream,
+		MultilinePatternKey:    testMultilinePattern,
+		DatetimeFormatKey:      testDatetimeFormat,
+		EndpointKey:            testEndpoint,
+	}
+
+	config := getAWSLogsConfig(argsWithoutHeader)
+	require.Equal(t, expectedConfig, config)
+}
+
+// TestLogFormatHeaderIsNotCompatibleWithDatetimeOrMultilineFormat tests if validateLogOptCompatability function
+// correctly validates that LogFormatKey cannot be configured with DatetimeFormatKey or MultilineFormatKey.
+func TestLogFormatHeaderIsNotCompatibleWithDatetimeOrMultilineFormat(t *testing.T) {
+	expectedConfig := map[string]string{
+		GroupKey:               testGroup,
+		RegionKey:              testRegion,
+		StreamKey:              testStream,
+		CredentialsEndpointKey: testCredentialsEndpoint,
+		CreateGroupKey:         testCreateGroup,
+		CreateStreamKey:        testCreateStream,
+		DatetimeFormatKey:      testDatetimeFormat,
+		EndpointKey:            testEndpoint,
+		LogFormatKey:           testJSONEmfLogformat,
+	}
+
+	config := getAWSLogsConfig(argsWithoutMultiline)
+	require.Equal(t, expectedConfig, config)
+	err := validateLogOptCompatability(config)
+	require.EqualError(t, err,
+		"you cannot configure log opt 'awslogs-datetime-format' or "+
+			"'awslogs-multiline-pattern' when log opt 'awslogs-format' is set to 'json/emf'")
+}
+
+// TestLogFormatHeaderIsNotCompatibleWithDatetimeOrMultilineFormat tests if validateLogOptCompatability function
+// correctly validates that LogFormatKey cannot be configured with DatetimeFormatKey or MultilineFormatKey.
+func TestValidateLogOptsDoesntErrorWithGoodConfig(t *testing.T) {
+	expectedConfig := map[string]string{
+		GroupKey:               testGroup,
+		RegionKey:              testRegion,
+		StreamKey:              testStream,
+		CredentialsEndpointKey: testCredentialsEndpoint,
+		CreateGroupKey:         testCreateGroup,
+		CreateStreamKey:        testCreateStream,
+		MultilinePatternKey:    testMultilinePattern,
+		EndpointKey:            testEndpoint,
+	}
+
+	config := getAWSLogsConfig(argsValid)
+	require.Equal(t, expectedConfig, config)
+	err := validateLogOptCompatability(config)
+	require.NoError(t, err)
 }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/shim-loggers-for-containerd/issues/285

*Description of changes:*
aws log driver supports an option to specify a log format sent in the header to `PutLogEvents`. 

Added an option to to allow specifying this log format in the shim config. 'json/emf' is the only supported format at the moment and this is validated by the log driver [Ref](https://github.com/moby/moby/blob/master/daemon/logger/awslogs/cloudwatchlogs.go#L787-L790)

Currently this header does not need to be specified in most regions but EMF auto detection is not launched in all aws regions requiring consumers of this shim to migrate to another driver such as Firelens. Adding the option to explicitly pass this header as an option would allow consumers to continue using EMF with the aws logs driver shim for containerd in regions missing EMF auto detect.

[Ref for initial feature request to aws logs driver](https://github.com/moby/moby/pull/42838)

https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Embedded_Metric_Format_Generation_PutLogEvents.html
https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Embedded_Metric_Format_Specification.html


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
