### PR TITLE
fix - Fix flag parsing errors and add missing fluentd write timeout flag

### DIFF
--- a/e2e/fluentd_test.go
+++ b/e2e/fluentd_test.go
@@ -25,6 +25,7 @@ const (
 	fluentdSubSecondPrecisionKey = "--fluentd-sub-second-precision"
 	fluentdBufferLimitKey        = "--fluentd-buffer-limit"
 	fluentdTagKey                = "--fluentd-tag"
+	fluentdWriteTimeoutKey       = "--fluentd-write-timeout"
 	testFluentdTag               = "test-tag"
 	timePattern                  = `^(\d{4})-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9][+-](0[0-9]|1[0-3]):[0-5][0-9]$` //nolint:lll // regex
 )
@@ -98,6 +99,20 @@ var testFluentd = func() {
 			err := SendTestLogByContainerd(creator, testLog)
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 			validateTestLogsInFluentd(fluentdLogDirName, testLog, testFluentdTag)
+		})
+		ginkgo.It("should send logs to fluentd log driver with write timeout set", func() {
+			testLog := testLogPrefix + uuid.New().String()
+			args := map[string]string{
+				LogDriverTypeKey:       FluentdDriverName,
+				ContainerIDKey:         TestContainerID,
+				ContainerNameKey:       TestContainerName,
+				fluentdAsyncConnectKey: "true",
+				fluentdWriteTimeoutKey: "5s",
+			}
+			creator := cio.BinaryIO(*Binary, args)
+			err := SendTestLogByContainerd(creator, testLog)
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+			validateTestLogsInFluentd(fluentdLogDirName, testLog, TestContainerID)
 		})
 	})
 }

--- a/init.go
+++ b/init.go
@@ -4,6 +4,8 @@
 package main
 
 import (
+	"time"
+
 	"github.com/spf13/pflag"
 
 	"github.com/aws/shim-loggers-for-containerd/logger/awslogs"
@@ -116,6 +118,7 @@ func initFluentdOpts() {
 	pflag.Bool(fluentd.SubsecondPrecisionKey, true, "Ensures event logs are generated in nanosecond resolution.")
 	pflag.Int(fluentd.BufferLimitKey, -1, "The number of events buffered on the memory")
 	pflag.String(fluentd.FluentdTagKey, "", "The tag used to identify log messages")
+	pflag.Duration(fluentd.WriteTimeoutKey, 5*time.Second, "Write timeout value for Fluentd writes")
 }
 
 // initSplunkOpts initialize splunk driver specified options.

--- a/main.go
+++ b/main.go
@@ -30,7 +30,15 @@ func init() {
 }
 
 func main() {
-	pflag.Parse()
+	// Ensure that we don't panic or exit out without logging if there are issues parsing
+	// flags. Those tend to be hard to debug.
+	pflag.CommandLine.Init(logger.DaemonName, pflag.ContinueOnError)
+	// pflag.Parse() will panic out if there are issues parsing flags. Using CommandLine.Parse()
+	// gives us a chance to gracefully handle the error.
+	if err := pflag.CommandLine.Parse(os.Args[1:]); err != nil {
+		debug.SendEventsToLog(logger.DaemonName, err.Error(), debug.ERROR, 1)
+		os.Exit(1)
+	}
 	if err := run(); err != nil {
 		debug.SendEventsToLog(logger.DaemonName, err.Error(), debug.ERROR, 1)
 		os.Exit(1)


### PR DESCRIPTION

## Summary

This PR fixes an issue with flag parsing that could cause the application to panic and adds a missing flag definition for the fluentd write timeout feature.

## What's Changed

### 🐛 Bug Fixes
- **Fixed flag parsing panics**: Replaced `pflag.Parse()` with `pflag.CommandLine.Parse()` to gracefully handle flag parsing errors instead of panicking
- **Added missing fluentd write timeout flag**: Added the missing `pflag` definition for `fluentd-write-timeout` in `init.go`
- **Improved error logging**: Flag parsing errors are now properly logged before application exit

### 🔧 Technical Details

#### Flag Parsing Fix
- **Problem**: `pflag.Parse()` panics on invalid flags, making debugging difficult
- **Solution**: Use `pflag.CommandLine.Parse(os.Args[1:])` which returns errors that can be handled gracefully
- **Benefit**: Better debugging experience with proper error messages logged before exit

#### Missing Flag Definition
- **Problem**: The fluentd write timeout feature was implemented but the flag definition was missing from `init.go`
- **Solution**: Added proper flag initialization for `fluentd-write-timeout`
- **Impact**: Users can now properly configure fluentd write timeouts via command line flags

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
