### PR TITLE
feat: pass splunk token in env variable

### DIFF
--- a/init.go
+++ b/init.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
 
 	"github.com/aws/shim-loggers-for-containerd/logger/awslogs"
 	"github.com/aws/shim-loggers-for-containerd/logger/fluentd"
@@ -122,6 +123,10 @@ func initFluentdOpts() {
 // Argument usage taken from https://docs.docker.com/config/containers/logging/splunk/.
 func initSplunkOpts() {
 	pflag.String(splunk.TokenKey, "", "Splunk HTTP Event Collector token.")
+	// Bind environment variable to the token flag for secure credential passing.
+	// Error is discarded because BindEnv only fails when called with no arguments,
+	// which will never happen here.
+	_ = viper.BindEnv(splunk.TokenKey, splunk.TokenEnvKey)
 	pflag.String(splunk.URLKey, "", "Path to your Splunk Enterprise, self-service Splunk Cloud instance, "+
 		"or Splunk Cloud managed cluster (including port and scheme used by HTTP Event Collector).")
 	pflag.String(splunk.SourceKey, "", "Event source.")

--- a/logger/splunk/logger.go
+++ b/logger/splunk/logger.go
@@ -24,8 +24,9 @@ const (
 
 	// Required.
 
-	TokenKey = "splunk-token"
-	URLKey   = "splunk-url"
+	TokenKey    = "splunk-token"
+	TokenEnvKey = "SPLUNK_TOKEN"
+	URLKey      = "splunk-url"
 
 	// Optional.
 


### PR DESCRIPTION
This change adds the option to pass the Splunk token to the shim-logger in the SPLUNK_TOKEN environment variable, in addition to the existing command line argument. Environment variables are generally more secure, and recommended over argv.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
