### PR TITLE
feat: Support endpoint-based secret fetching

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ The following list of arguments apply to all of the shim logger binaries in this
 | container-image-id | No | The container image id. This is part of the docker config variables that can be logged by splunk log driver. |
 | container-image-name | No | The container image name. This is part of the docker config variables that can be logged by splunk log driver. |
 | container-env | No | The container environment variables map in json format. This is part of the docker config variables that can be logged by splunk log driver. |
+| container-env-endpoint | No | Endpoint URL to fetch container environment variables. When set, the shim logger fetches the env from this endpoint instead of using `container-env`. The endpoint must return JSON in the form `{"env": {"KEY": "VALUE"}}`. |
 | container-labels | No | The container labels map in json format. This is part of the docker config variables that can be logged by splunk log driver. |
 
 ### Windows specific arguments
@@ -105,24 +106,25 @@ The following additional arguments are supported for the `awslogs` shim logger b
 The following additional arguments are supported for the `splunk` shim logger binary, which can be used to send container logs to [splunk](https://www.splunk.com/en_us/central-log-management.html).
 You can find a description of what these parameters are used for [here](https://docs.docker.com/config/containers/logging/splunk/).
 
-|Name|Required|
-|-|-|
-| splunk-token | Yes |
-| splunk-url | Yes |
-| splunk-source | No |
-| splunk-sourcetype | No |
-| splunk-index | No |
-| splunk-capath | No |
-| splunk-caname | No |
-| splunk-insecureskipverify | No |
-| splunk-format | No |
-| splunk-verify-connection | No |
-| splunk-gzip | No |
-| splunk-gzip-level | No |
-| splunk-tag | No |
-| labels | No |
-| env | No |
-| env-regex | No |
+|Name|Required|Description|
+|-|-|-|
+| splunk-token | Yes | Splunk HTTP Event Collector token. Not required when `splunk-token-endpoint` is set. |
+| splunk-token-endpoint | No | Endpoint URL to fetch the Splunk token. When set, the token is fetched from this endpoint instead of using `splunk-token`. The endpoint must return JSON in the form `{"token": "VALUE"}`. |
+| splunk-url | Yes | |
+| splunk-source | No | |
+| splunk-sourcetype | No | |
+| splunk-index | No | |
+| splunk-capath | No | |
+| splunk-caname | No | |
+| splunk-insecureskipverify | No | |
+| splunk-format | No | |
+| splunk-verify-connection | No | |
+| splunk-gzip | No | |
+| splunk-gzip-level | No | |
+| splunk-tag | No | |
+| labels | No | |
+| env | No | |
+| env-regex | No | |
 
 #### Fluentd
 

--- a/args.go
+++ b/args.go
@@ -98,20 +98,9 @@ func getDockerConfigs() (*logger.DockerConfigs, error) {
 		}
 	}
 
-	containerEnvString := viper.GetString(ContainerEnvKey)
-	containerEnv := make([]string, 0)
-	if containerEnvString != "" {
-		containerEnvMap := make(map[string]string)
-		err := json.Unmarshal([]byte(containerEnvString), &containerEnvMap)
-		if err != nil {
-			return nil, err
-		}
-		// Docker logging use a slice to store the environment variables
-		// Each item is in the format of "key=value"
-		// ref: https://github.com/moby/moby/blob/c833222d54c00d64a0fc44c561a5973ecd414053/daemon/logger/loginfo.go#L60
-		for envKey, envVal := range containerEnvMap {
-			containerEnv = append(containerEnv, envKey+"="+envVal)
-		}
+	containerEnv, err := getContainerEnv()
+	if err != nil {
+		return nil, err
 	}
 
 	// Docker config variables are optional
@@ -191,7 +180,7 @@ func getFluentdArgs() *fluentd.Args {
 
 // getSplunkArgs gets Splunk specified arguments for Splunk log driver.
 func getSplunkArgs() (*splunk.Args, error) {
-	token, err := getRequiredValue(splunk.TokenKey)
+	token, err := getSplunkToken()
 	if err != nil {
 		return nil, err
 	}
@@ -219,6 +208,65 @@ func getSplunkArgs() (*splunk.Args, error) {
 		Env:                viper.GetString(splunk.EnvKey),
 		EnvRegex:           viper.GetString(splunk.EnvRegexKey),
 	}, nil
+}
+
+// getSplunkToken fetches the Splunk token from the endpoint if
+// --splunk-token-endpoint is set, otherwise falls back to the
+// --splunk-token / SPLUNK_TOKEN argument.
+func getSplunkToken() (string, error) {
+	splunkTokenEndpoint := viper.GetString(splunk.TokenEndpointKey)
+	if splunkTokenEndpoint != "" {
+		body, err := fetchFromEndpoint(splunkTokenEndpoint)
+		if err != nil {
+			return "", fmt.Errorf("unable to fetch splunk token from endpoint: %w", err)
+		}
+		var resp SplunkTokenResponse
+		if err := json.Unmarshal(body, &resp); err != nil {
+			return "", fmt.Errorf("failed to decode response from %s: %w", splunkTokenEndpoint, err)
+		}
+		if resp.Token == "" {
+			return "", fmt.Errorf("endpoint %s returned an empty splunk token", splunkTokenEndpoint)
+		}
+		return resp.Token, nil
+	}
+	return getRequiredValue(splunk.TokenKey)
+}
+
+// getContainerEnv fetches container environment variables from the endpoint
+// if --container-env-endpoint is set, otherwise falls back to the
+// --container-env argument.
+func getContainerEnv() ([]string, error) {
+	containerEnvEndpoint := viper.GetString(ContainerEnvEndpointKey)
+	if containerEnvEndpoint != "" {
+		body, err := fetchFromEndpoint(containerEnvEndpoint)
+		if err != nil {
+			return nil, fmt.Errorf("unable to fetch container env from endpoint: %w", err)
+		}
+		var resp ContainerEnvResponse
+		if err := json.Unmarshal(body, &resp); err != nil {
+			return nil, fmt.Errorf("failed to decode response from %s: %w", containerEnvEndpoint, err)
+		}
+		containerEnv := make([]string, 0, len(resp.Env))
+		for envKey, envVal := range resp.Env {
+			containerEnv = append(containerEnv, envKey+"="+envVal)
+		}
+		return containerEnv, nil
+	}
+
+	// Fall back to existing --container-env argument.
+	containerEnvString := viper.GetString(ContainerEnvKey)
+	if containerEnvString == "" {
+		return []string{}, nil
+	}
+	containerEnvMap := make(map[string]string)
+	if err := json.Unmarshal([]byte(containerEnvString), &containerEnvMap); err != nil {
+		return nil, err
+	}
+	containerEnv := make([]string, 0, len(containerEnvMap))
+	for envKey, envVal := range containerEnvMap {
+		containerEnv = append(containerEnv, envKey+"="+envVal)
+	}
+	return containerEnv, nil
 }
 
 // getRequiredValue parses required arguments or exits if any is missing.

--- a/args_test.go
+++ b/args_test.go
@@ -7,8 +7,11 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"math"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"reflect"
 	"testing"
@@ -497,4 +500,280 @@ func TestGetSplunkArgs(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestGetSplunkToken tests the getSplunkToken function with endpoint-based
+// fetching and fallback to the direct --splunk-token argument.
+// Not parallel: tests share viper global state.
+func TestGetSplunkToken(t *testing.T) {
+	tests := []struct {
+		name          string
+		setupServer   func() *httptest.Server
+		setupViper    func(serverURL string)
+		expectedToken string
+		expectErr     bool
+		errContains   string
+	}{
+		{
+			name: "token fetched from endpoint",
+			setupServer: func() *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					resp := SplunkTokenResponse{Token: "endpoint-token"}
+					_ = json.NewEncoder(w).Encode(resp)
+				}))
+			},
+			setupViper: func(serverURL string) {
+				viper.Set(splunk.TokenEndpointKey, serverURL)
+			},
+			expectedToken: "endpoint-token",
+			expectErr:     false,
+		},
+		{
+			name:        "fallback to direct token when endpoint not set",
+			setupServer: nil,
+			setupViper: func(_ string) {
+				viper.Set(splunk.TokenKey, "direct-token")
+			},
+			expectedToken: "direct-token",
+			expectErr:     false,
+		},
+		{
+			name: "error when endpoint returns non-200",
+			setupServer: func() *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					w.WriteHeader(http.StatusNotFound)
+				}))
+			},
+			setupViper: func(serverURL string) {
+				viper.Set(splunk.TokenEndpointKey, serverURL)
+			},
+			expectErr:   true,
+			errContains: "unable to fetch splunk token from endpoint",
+		},
+		{
+			name: "error when endpoint returns invalid JSON",
+			setupServer: func() *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					_, _ = fmt.Fprint(w, "not-json")
+				}))
+			},
+			setupViper: func(serverURL string) {
+				viper.Set(splunk.TokenEndpointKey, serverURL)
+			},
+			expectErr:   true,
+			errContains: "failed to decode response from",
+		},
+		{
+			name:        "error when neither endpoint nor direct arg is provided",
+			setupServer: nil,
+			setupViper:  func(_ string) {},
+			expectErr:   true,
+			errContains: "splunk-token is required",
+		},
+		{
+			name: "error when endpoint returns empty token",
+			setupServer: func() *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					resp := SplunkTokenResponse{Token: ""}
+					_ = json.NewEncoder(w).Encode(resp)
+				}))
+			},
+			setupViper: func(serverURL string) {
+				viper.Set(splunk.TokenEndpointKey, serverURL)
+			},
+			expectErr:   true,
+			errContains: "returned an empty splunk token",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			defer viper.Reset()
+
+			var serverURL string
+			if tc.setupServer != nil {
+				server := tc.setupServer()
+				defer server.Close()
+				serverURL = server.URL
+			}
+			tc.setupViper(serverURL)
+
+			token, err := getSplunkToken()
+			if tc.expectErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.errContains)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tc.expectedToken, token)
+			}
+		})
+	}
+}
+
+// TestGetSplunkArgsWithEndpoint tests that getSplunkArgs correctly uses the
+// token fetched from the endpoint when --splunk-token-endpoint is set.
+// Not parallel: tests share viper global state.
+func TestGetSplunkArgsWithEndpoint(t *testing.T) {
+	const testURL = "https://splunk.example.com:8088"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		resp := SplunkTokenResponse{Token: "endpoint-fetched-token"}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+	defer viper.Reset()
+
+	viper.Set(splunk.TokenEndpointKey, server.URL)
+	viper.Set(splunk.URLKey, testURL)
+
+	args, err := getSplunkArgs()
+	require.NoError(t, err)
+	assert.Equal(t, "endpoint-fetched-token", args.Token)
+	assert.Equal(t, testURL, args.URL)
+}
+
+// TestGetContainerEnv tests the getContainerEnv function with endpoint-based
+// fetching and fallback to the direct --container-env argument.
+// Not parallel: tests share viper global state.
+func TestGetContainerEnv(t *testing.T) {
+	tests := []struct {
+		name        string
+		setupServer func() *httptest.Server
+		setupViper  func(serverURL string)
+		expectedEnv map[string]struct{}
+		expectErr   bool
+		errContains string
+	}{
+		{
+			name: "env fetched from endpoint",
+			setupServer: func() *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					resp := ContainerEnvResponse{Env: map[string]string{"KEY1": "val1", "KEY2": "val2"}}
+					_ = json.NewEncoder(w).Encode(resp)
+				}))
+			},
+			setupViper: func(serverURL string) {
+				viper.Set(ContainerEnvEndpointKey, serverURL)
+			},
+			expectedEnv: map[string]struct{}{
+				"KEY1=val1": {},
+				"KEY2=val2": {},
+			},
+			expectErr: false,
+		},
+		{
+			name:        "fallback to direct env when endpoint not set",
+			setupServer: nil,
+			setupViper: func(_ string) {
+				viper.Set(ContainerEnvKey, `{"env0":"envValue0","env1":"envValue1"}`)
+			},
+			expectedEnv: map[string]struct{}{
+				"env0=envValue0": {},
+				"env1=envValue1": {},
+			},
+			expectErr: false,
+		},
+		{
+			name:        "empty env when neither endpoint nor direct arg is provided",
+			setupServer: nil,
+			setupViper:  func(_ string) {},
+			expectedEnv: map[string]struct{}{},
+			expectErr:   false,
+		},
+		{
+			name: "error when endpoint returns non-200",
+			setupServer: func() *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					w.WriteHeader(http.StatusNotFound)
+				}))
+			},
+			setupViper: func(serverURL string) {
+				viper.Set(ContainerEnvEndpointKey, serverURL)
+			},
+			expectErr:   true,
+			errContains: "unable to fetch container env from endpoint",
+		},
+		{
+			name: "error when endpoint returns invalid JSON",
+			setupServer: func() *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					_, _ = fmt.Fprint(w, "not-json")
+				}))
+			},
+			setupViper: func(serverURL string) {
+				viper.Set(ContainerEnvEndpointKey, serverURL)
+			},
+			expectErr:   true,
+			errContains: "failed to decode response from",
+		},
+		{
+			name:        "error when direct env arg is malformed JSON",
+			setupServer: nil,
+			setupViper: func(_ string) {
+				viper.Set(ContainerEnvKey, "{invalidJson")
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			defer viper.Reset()
+
+			var serverURL string
+			if tc.setupServer != nil {
+				server := tc.setupServer()
+				defer server.Close()
+				serverURL = server.URL
+			}
+			tc.setupViper(serverURL)
+
+			env, err := getContainerEnv()
+			if tc.expectErr {
+				require.Error(t, err)
+				if tc.errContains != "" {
+					require.Contains(t, err.Error(), tc.errContains)
+				}
+			} else {
+				require.NoError(t, err)
+				gotEnv := make(map[string]struct{})
+				for _, v := range env {
+					gotEnv[v] = struct{}{}
+				}
+				assert.DeepEqual(t, tc.expectedEnv, gotEnv)
+			}
+		})
+	}
+}
+
+// TestGetDockerConfigsWithEndpoint tests that getDockerConfigs correctly uses
+// the container env fetched from the endpoint when --container-env-endpoint
+// is set.
+// Not parallel: tests share viper global state.
+func TestGetDockerConfigsWithEndpoint(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		resp := ContainerEnvResponse{Env: map[string]string{"KEY1": "val1", "KEY2": "val2"}}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+	defer viper.Reset()
+
+	viper.Set(ContainerEnvEndpointKey, server.URL)
+	viper.Set(ContainerImageNameKey, testContainerImageName)
+	viper.Set(ContainerImageIDKey, testContainerImageID)
+
+	args, err := getDockerConfigs()
+	require.NoError(t, err)
+	assert.Equal(t, testContainerImageName, args.ContainerImageName)
+	assert.Equal(t, testContainerImageID, args.ContainerImageID)
+
+	gotEnv := make(map[string]struct{})
+	for _, v := range args.ContainerEnv {
+		gotEnv[v] = struct{}{}
+	}
+	expectedEnv := map[string]struct{}{
+		"KEY1=val1": {},
+		"KEY2=val2": {},
+	}
+	assert.DeepEqual(t, expectedEnv, gotEnv)
 }

--- a/endpoint_fetch.go
+++ b/endpoint_fetch.go
@@ -1,0 +1,58 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// SplunkTokenResponse is the JSON response body returned by the splunk token endpoint.
+type SplunkTokenResponse struct {
+	Token string `json:"token"`
+}
+
+// ContainerEnvResponse is the JSON response body returned by the container env endpoint.
+type ContainerEnvResponse struct {
+	Env map[string]string `json:"env"`
+}
+
+// httpClient is used by fetchFromEndpoint so that requests have a bounded deadline.
+var httpClient = &http.Client{Timeout: 5 * time.Second}
+
+// maxResponseBytes is the upper bound on how many bytes fetchFromEndpoint will
+// read from any endpoint response. This prevents unbounded memory consumption
+// if an endpoint misbehaves and returns a very large body.
+const maxResponseBytes = 1 << 20 // 1 MiB
+
+// maxErrBodyBytes is the upper bound on how many bytes of an error response
+// body are included in the returned error message.
+const maxErrBodyBytes = 512
+
+// fetchFromEndpoint issues an HTTP GET to the given URL and returns the response
+// body bytes. On non-200 status or network error, it returns a descriptive error
+// including the HTTP status code, endpoint URL, and a truncated snippet of the
+// response body.
+func fetchFromEndpoint(url string) ([]byte, error) {
+	resp, err := httpClient.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch from %s: %w", url, err)
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		errBody, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrBodyBytes))
+		return nil, fmt.Errorf("failed to fetch from %s: HTTP %d: %s", url, resp.StatusCode, string(errBody))
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response from %s: %w", url, err)
+	}
+	return body, nil
+}

--- a/endpoint_fetch_test.go
+++ b/endpoint_fetch_test.go
@@ -1,0 +1,90 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build unit
+
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFetchFromEndpoint tests the fetchFromEndpoint helper with various HTTP
+// response scenarios.
+func TestFetchFromEndpoint(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		statusCode   int
+		responseBody string
+		expectErr    bool
+		errContains  string
+		expectedBody string
+	}{
+		{
+			name:         "successful fetch returns body",
+			statusCode:   http.StatusOK,
+			responseBody: `{"token":"secret-value"}`,
+			expectErr:    false,
+			expectedBody: `{"token":"secret-value"}`,
+		},
+		{
+			name:         "non-200 response returns error with status code and body",
+			statusCode:   http.StatusNotFound,
+			responseBody: `{"code":"NotFound","message":"not found"}`,
+			expectErr:    true,
+			errContains:  "HTTP 404",
+		},
+		{
+			name:         "internal server error returns error with status code and body",
+			statusCode:   http.StatusInternalServerError,
+			responseBody: `{"code":"InternalServerError","message":"error"}`,
+			expectErr:    true,
+			errContains:  "HTTP 500",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tc.statusCode)
+				_, _ = fmt.Fprint(w, tc.responseBody)
+			}))
+			defer server.Close()
+
+			body, err := fetchFromEndpoint(server.URL)
+			if tc.expectErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.errContains)
+				assert.Contains(t, err.Error(), server.URL)
+				// Verify the error includes the response body snippet for debugging.
+				if tc.responseBody != "" {
+					assert.Contains(t, err.Error(), tc.responseBody)
+				}
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tc.expectedBody, string(body))
+			}
+		})
+	}
+}
+
+// TestFetchFromEndpointNetworkError tests that a network error returns a
+// descriptive error including the URL.
+func TestFetchFromEndpointNetworkError(t *testing.T) {
+	t.Parallel()
+
+	body, err := fetchFromEndpoint("http://127.0.0.1:0/nonexistent")
+	require.Error(t, err)
+	assert.Nil(t, body)
+	assert.Contains(t, err.Error(), "failed to fetch from")
+}

--- a/init.go
+++ b/init.go
@@ -44,6 +44,9 @@ const (
 	ContainerImageNameKey = "container-image-name"
 	// ContainerEnvKey represents the key for the container's environment variables.
 	ContainerEnvKey = "container-env"
+
+	// ContainerEnvEndpointKey denotes the endpoint URL to fetch container environment variables.
+	ContainerEnvEndpointKey = "container-env-endpoint"
 	// ContainerLabelsKey represents the key for the container's labels.
 	ContainerLabelsKey = "container-labels"
 
@@ -84,6 +87,7 @@ func initDockerConfigOpts() {
 	pflag.String(ContainerImageIDKey, "", "Image id of the container")
 	pflag.String(ContainerImageNameKey, "", "Image name of the container")
 	pflag.String(ContainerEnvKey, "", "Environment variables of the container")
+	pflag.String(ContainerEnvEndpointKey, "", "Endpoint URL to fetch container environment variables.")
 	pflag.String(ContainerLabelsKey, "", "Labels of the container")
 }
 
@@ -123,6 +127,7 @@ func initFluentdOpts() {
 // Argument usage taken from https://docs.docker.com/config/containers/logging/splunk/.
 func initSplunkOpts() {
 	pflag.String(splunk.TokenKey, "", "Splunk HTTP Event Collector token.")
+	pflag.String(splunk.TokenEndpointKey, "", "Endpoint URL to fetch Splunk token.")
 	// Bind environment variable to the token flag for secure credential passing.
 	// Error is discarded because BindEnv only fails when called with no arguments,
 	// which will never happen here.

--- a/logger/splunk/logger.go
+++ b/logger/splunk/logger.go
@@ -26,7 +26,9 @@ const (
 
 	TokenKey    = "splunk-token"
 	TokenEnvKey = "SPLUNK_TOKEN"
-	URLKey      = "splunk-url"
+	// TokenEndpointKey denotes the endpoint URL to fetch the Splunk token.
+	TokenEndpointKey = "splunk-token-endpoint" //nolint:gosec // not a credential
+	URLKey           = "splunk-url"
 
 	// Optional.
 

--- a/scripts/start-localstack
+++ b/scripts/start-localstack
@@ -1,11 +1,22 @@
 #!/bin/bash
-# Copy from https://docs.localstack.cloud/user-guide/ci/github-actions/
+set -euo pipefail
 
-LOCALSTACK_VERSION=2.2.0
-pip install localstack==${LOCALSTACK_VERSION} awscli-local[ver1] # install LocalStack cli and awslocal
-docker pull localstack/localstack:${LOCALSTACK_VERSION}         # Make sure to pull the latest version of the image
-localstack start -d                       # Start LocalStack in the background
+# LocalStack CI setup.
+# See https://docs.localstack.cloud/user-guide/ci/github-actions/
+#
+# The official LocalStack/setup-localstack GitHub Action installs the latest
+# CLI, which requires a LocalStack account (as of CLI 2026.3.0+). We use this
+# manual script instead to pin the CLI version and avoid the account requirement.
+LOCALSTACK_VERSION=3.8.1
 
-echo "Waiting for LocalStack startup..."  # Wait 30 seconds for the LocalStack container
-localstack wait -t 30                     # to become ready before timing out
+pip install localstack==${LOCALSTACK_VERSION} awscli-local[ver1]
+docker pull localstack/localstack:${LOCALSTACK_VERSION}
+
+# Set IMAGE_NAME so LocalStack uses the already-pulled image directly
+# instead of downloading a second runtime image via Docker-in-Docker.
+export IMAGE_NAME="localstack/localstack:${LOCALSTACK_VERSION}"
+
+localstack start -d
+echo "Waiting for LocalStack startup..."
+localstack wait -t 30
 echo "Startup complete"


### PR DESCRIPTION
### Description

Add support for fetching secrets (Splunk token, container environment variables) from HTTP endpoints instead of requiring them as direct CLI arguments.

Two new flags are introduced:
- `--splunk-token-endpoint`: fetches the Splunk token from an HTTP endpoint
- `--container-env-endpoint`: fetches container environment variables from an HTTP endpoint

When an endpoint flag is set, it takes precedence over the corresponding direct argument (`--splunk-token`, `--container-env`).

### Changes

- `args.go` / `args_test.go`: add new endpoint flags and resolution logic with tests
- `endpoint_fetch.go` / `endpoint_fetch_test.go`: HTTP client for fetching secrets from endpoints
- `init.go`: register the new flags
- `logger/splunk/logger.go`: use resolved token value
- `scripts/start-localstack`: fix CI LocalStack startup (bump to 3.8.1, set `IMAGE_NAME` to avoid Docker-in-Docker failure)

### Testing

- Unit tests added for endpoint fetching and argument resolution
- E2E tests pass with LocalStack CI fix


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
