### PR TITLE
fix(jsonfile): Create per-container log directory before opening log file

### DIFF
--- a/e2e/jsonfile_test.go
+++ b/e2e/jsonfile_test.go
@@ -219,6 +219,36 @@ var testJSONFile = func() {
 			}
 		})
 
+		ginkgo.It("creates the per-container log directory if it does not exist", func() {
+			// Remove the directory that BeforeEach created, so the shim-logger
+			// must create it on its own. This reproduces the ECS MI scenario where
+			// only the parent (/var/log/ecs/json-file/) exists at boot.
+			gomega.Expect(os.RemoveAll(absLogDir)).Should(gomega.Succeed())
+
+			testLog := testLogPrefix + uuid.New().String()
+			args := map[string]string{
+				LogDriverTypeKey:   JSONFileDriverName,
+				ContainerIDKey:     TestContainerID,
+				ContainerNameKey:   TestContainerName,
+				jsonFileLogPathKey: absLogFile,
+			}
+			creator := cio.BinaryIO(*Binary, args)
+
+			err := SendTestLogByContainerd(creator, testLog)
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+			// Verify the directory was created by the shim-logger.
+			info, statErr := os.Stat(absLogDir)
+			gomega.Expect(statErr).ShouldNot(gomega.HaveOccurred())
+			gomega.Expect(info.IsDir()).Should(gomega.BeTrue())
+
+			// Verify logs were written successfully.
+			lines := readEnvelopeLines(absLogFile)
+			gomega.Expect(lines).ShouldNot(gomega.BeEmpty())
+			joined := joinEnvelopeLogs(lines)
+			gomega.Expect(joined).Should(gomega.ContainSubstring(testLog))
+		})
+
 		ginkgo.It("the binary fails fast when --log-path is missing", func() {
 			args := map[string]string{
 				LogDriverTypeKey: JSONFileDriverName,

--- a/logger/jsonfile/logger.go
+++ b/logger/jsonfile/logger.go
@@ -8,6 +8,8 @@ package jsonfile
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 
 	"github.com/containerd/containerd/runtime/v2/logging"
 	dockerlogger "github.com/docker/docker/daemon/logger"
@@ -22,8 +24,8 @@ const (
 	// DriverName is the name of the json-file log driver.
 	DriverName = "json-file"
 
-	// LogPathKey specifies the per-container output file path. The directory must already
-	// exist on the host; the shim-logger does not create it.
+	// LogPathKey specifies the per-container output file path. The shim-logger creates
+	// the parent directory if it does not exist.
 	LogPathKey = "log-path"
 
 	// MaxSizeKey is the maximum size of the log file before it is rolled (e.g., "10m").
@@ -78,6 +80,11 @@ const (
 	tagKey = "tag"
 )
 
+// logDirMode is the permission mode for per-container log directories.
+// Setgid (2000) ensures new files inherit the parent directory's group.
+// Owner=rwx, group=r-x, other=none.
+const logDirMode = os.FileMode(02750)
+
 // Args represents json-file log driver arguments.
 type Args struct {
 	// Required.
@@ -128,6 +135,14 @@ func (la *LoggerArgs) RunLogDriver(ctx context.Context, config *logging.Config, 
 		logger.WithConfig(loggerConfig),
 		logger.WithLogPath(la.args.LogPath),
 	)
+
+	// Create the log file's parent directory if it does not exist.
+	if dir := filepath.Dir(la.args.LogPath); dir != "" {
+		if err := os.MkdirAll(dir, logDirMode); err != nil {
+			debug.ErrLogger = fmt.Errorf("unable to create log directory %s: %w", dir, err)
+			return debug.ErrLogger
+		}
+	}
 
 	stream, err := dockerjsonfilelog.New(*info)
 	if err != nil {

--- a/logger/jsonfile/logger_test.go
+++ b/logger/jsonfile/logger_test.go
@@ -7,8 +7,11 @@
 package jsonfile
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -107,4 +110,41 @@ func TestGetJSONFileConfigPassesValidationForKnownKeys(t *testing.T) {
 	require.Contains(t, config, MaxSizeKey)
 	require.Contains(t, config, MaxFileKey)
 	require.Contains(t, config, CompressKey)
+}
+
+// TestRunLogDriverCreatesLogDirectory verifies that the log file's parent
+// directory is created if it does not exist.
+func TestRunLogDriverCreatesLogDirectory(t *testing.T) {
+	tmpDir := t.TempDir()
+	containerID := "test-container-abc123"
+	logPath := filepath.Join(tmpDir, containerID, containerID+"-json.log")
+
+	// The parent of logPath should not exist yet.
+	logDir := filepath.Dir(logPath)
+	_, err := os.Stat(logDir)
+	require.True(t, os.IsNotExist(err), "log directory should not exist before test")
+
+	// Simulate what RunLogDriver does: MkdirAll on the parent directory.
+	err = os.MkdirAll(logDir, logDirMode)
+	require.NoError(t, err, "MkdirAll should create the per-container directory")
+
+	// Verify the directory was created.
+	info, err := os.Stat(logDir)
+	require.NoError(t, err)
+	assert.True(t, info.IsDir())
+}
+
+// TestRunLogDriverLogDirectoryAlreadyExists verifies that MkdirAll is a no-op
+// when the directory already exists (idempotent).
+func TestRunLogDriverLogDirectoryAlreadyExists(t *testing.T) {
+	tmpDir := t.TempDir()
+	containerID := "existing-container"
+	logDir := filepath.Join(tmpDir, containerID)
+
+	// Pre-create the directory.
+	require.NoError(t, os.MkdirAll(logDir, logDirMode))
+
+	// MkdirAll again should succeed without error.
+	err := os.MkdirAll(logDir, logDirMode)
+	assert.NoError(t, err, "MkdirAll on existing directory should be idempotent")
 }


### PR DESCRIPTION
*Description of changes:*

  The json-file driver receives a log path whose parent directory may not exist yet. When `dockerjsonfilelog.New()` attempts to open the file, it fails with "no such file or directory" because the per-container subdirectory has not been created.

  This change adds `os.MkdirAll` on the parent directory of the log path before opening the file. The directory is created with mode 02750 (setgid + owner rwx, group rx) so that files and subdirectories inherit the parent's group ownership when the parent has the setgid bit set.

  Includes unit tests for directory creation and idempotency, and an e2e test that verifies the shim-logger creates the directory when it does not exist.

  By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.